### PR TITLE
Add concurrency with Promise.all to health check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,13 @@ export class HealthZ {
     health.host = hostStats()
 
     health.dependencies = {}
-    for (const dep of this.deps) {
+    await Promise.all(this.deps.map(async (dep) => {
       const d = await latency(dep.fn, ...dep.args)
       if (d.success !== true) {
         this.status = 500
       }
       health.dependencies[dep.name] = d
-    }
+    }));
 
     return health
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export class HealthZ {
     this.deps.push(new Dependency(name, fn, args))
   }
 
-  async getHealth (): Promise<Map<string, object>> {
+  async getHealth (): Promise<any> {
     const health = {} as any
     health.host = hostStats()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export class HealthZ {
         this.status = 500
       }
       health.dependencies[dep.name] = d
-    }));
+    }))
 
     return health
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export class HealthZ {
     this.deps.push(new Dependency(name, fn, args))
   }
 
-  async getHealth (): Promise<any> {
+  async getHealth (): Promise<Map<string, object>> {
     const health = {} as any
     health.host = hostStats()
 


### PR DESCRIPTION
- Use Promise.all so that health checks have lower chance of timing out.
- Add typings for output
- Obey lint
- Go back to any
